### PR TITLE
improve readme readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 ## What is this?
 
-This is my first assignment of a computer graphics course I'm currently taking. The topic is very basic, yet fun.
+First assignment of a computer graphics courst. The topic of the assignment is fundamental and fun.
 
-If you are doing a similar assignment for academic purposes, please be sure to acknowledge if you are to read or study my source code. This is most likely required to protect your academic integrity. For all other situations, [MIT license](LICENSE) applies.
+If you are doing a similar assignment for academic purposes and studying my source code, please be sure to acknowledge. This is most likely required to protect your academic integrity. For all other situations, [MIT license](LICENSE) applies.
 
 ## Get Started
 
 **Opening `index.html` directly from file system will *NOT* work!**
 
-This assignment is tested on Google Chrome 72.0.3626.81 and Firefox 65.0. This should, theoretically, work on all modern browsers, but just try not to grade this on IE. Webpack is used to package and transpile JavaScript source code as manually manage and integrate over 10 source modules can be problematic. In addition, shader sources are loaded asynchronously with `window.fetch()` function, which requires remote resources being hosted on a HTTP server. To correctly open this assignment, follow the instruction below.
+This assignment is tested on Google Chrome 72.0.3626.81 and Firefox 65.0. Theretically, the assignment works on all modern browsers, but try not to grade this on IE. Webpack is used to package and transpile JavaScript source code as manually manage and integrate over ten source modules can be problematic. In addition, shader sources are loaded asynchronously with `window.fetch()` function, which requires remote resources being hosted on an HTTP server. To correctly open this assignment, follow the instruction below.
 
 ### Online Demo
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-First assignment of a computer graphics courst. The topic of the assignment is fundamental and fun.
+First assignment of a computer graphics course. The topic of the assignment is fundamental and fun.
 
 If you are doing a similar assignment for academic purposes and studying my source code, please be sure to acknowledge. This is most likely required to protect your academic integrity. For all other situations, [MIT license](LICENSE) applies.
 


### PR DESCRIPTION
1. Remove the metadiscourse in the first sentence. The word "very basic" is replaced by "fundamental" because "fundamental" is concise.
2. The second sentence has two "if" clause in one sentence. Combine two "if" clauses into a single "if" clause.  "Read" and "Study" is entailment, so only keep "study".
3. Remove the hedging word "should", "just" in the third paragraph. Change the number 10 into word ten to make the readme formal. 
Fixes #2 